### PR TITLE
Add the choice to display user's edication.

### DIFF
--- a/exampleSite/content/authors/admin/_index.md
+++ b/exampleSite/content/authors/admin/_index.md
@@ -24,6 +24,9 @@ organizations:
 # Short bio (displayed in user profile at end of posts)
 bio: My research interests include distributed robotics, mobile computing and programmable matter.
 
+# Should the user's education and interests be displayed?
+display_education: false
+
 interests:
 - Artificial Intelligence
 - Computational Linguistics

--- a/layouts/partials/widgets/about.html
+++ b/layouts/partials/widgets/about.html
@@ -77,8 +77,8 @@
     {{ end }}
 
 
-
-    <!-- <div class="row">
+    {{ if $person.display_education }}
+    <div class="row">
 
       {{ with $person.education }}
       <div class="col-md-7">
@@ -108,6 +108,7 @@
       </div>
       {{ end }}
 
-    </div> -->
+    </div>
+    {{ end }}
   </div>
 </div>


### PR DESCRIPTION
### Purpose

This contribution adds a reference in the user widget to a value in the user's index file indicating whether the user's education should be displayed or not, instead of forcing people to create a custom theme if they want to display the education. 