### PR TITLE
added support for MS clarity

### DIFF
--- a/exampleSite/config/_default/params.toml
+++ b/exampleSite/config/_default/params.toml
@@ -1,6 +1,9 @@
 # SITE SETUP
 # Documentation: https://sourcethemes.com/academic/
 
+# marketing
+microsoft_clarity = ""
+
 # Color theme.
 #   Choose from `default`, `ocean`, `forest`, `dark`, `apogee`, `1950s`, `coffee`, `cupcake`, `strawberry`.
 color_theme = "default"

--- a/layouts/partials/site_head.html
+++ b/layouts/partials/site_head.html
@@ -118,6 +118,15 @@
   {{ end }}
 
   {{ if not site.IsServer }}
+  {{ if site.Params.microsoft_clarity }}
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+          c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+          t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+          y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "{{ site.Params.microsoft_clarity }}");
+    </script>
+  {{ end }}
   {{ if site.GoogleAnalytics }}
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;


### PR DESCRIPTION
Added support for MS Clarity in the template. It's controlled by configuration in `params.toml`. See example in exampleSite. 
I think the Google Analytics configuration should move to the same place. 