### PR TITLE
Upgrade Font Awesome to v7.0.1

### DIFF
--- a/exampleSite/data/assets.toml
+++ b/exampleSite/data/assets.toml
@@ -67,8 +67,8 @@
 # CSS
 
 [css.fontAwesome]
-  version = "5.6.0"
-  sri = "sha384-aOkxzJ5uQz7WBObEZcHvV5JvRW3TUc2rNPA7pe3AwnsUohiw1Vj2Rgx2KSOkF5+h"
+  version = "7.0.1"
+  sri = "sha384-rWj9FmWWt3OMqd9vBkWRhFavvVUYalYqGPoMdL1brs/qvvqz88gvLShYa4hKNyqb"
   url = "https://use.fontawesome.com/releases/v%s/css/all.css"
 [css.academicons]
   version = "1.8.6"


### PR DESCRIPTION
This commit upgrades Font Awesome to the currently latest version.

Also see https://github.com/gethugothemes/academia-hugo/pull/41#issuecomment-3315916017.